### PR TITLE
CFP end date for Codeurs en Seine is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A collection of awesome Call For Papers to never miss to speak anymore 🗣
 | **dotJS** | Paris | 09/11 | [CFP](https://eventil.com/events/dotjs-2018), [Website](https://www.dotjs.io/) | ~~30/04/2018~~
 | **DevOps D-Day** | Marseille | 15/11 | [CFP](https://docs.google.com/forms/d/e/1FAIpQLScOHPUjB2qxLEl91-wMPskpFR4NKIRZz_QFizPUgEpS1f73dw/viewform), [Website](http://2018.devops-dday.com/) | ~~21/06/2018~~
 | **Xebicon'18** | Paris | 20/11 | CFP, [Website](https://xebicon.fr/) | 
-| **Codeurs en Seine** | Rouen | 22/11 | [CFP](https://codeursenseine.cfp.io/), [Website](https://www.codeursenseine.com/2018/) | **15/09/2018**
+| **Codeurs en Seine** | Rouen | 22/11 | [CFP](https://codeursenseine.cfp.io/), [Website](https://www.codeursenseine.com/2018/) | **31/08/2018**
 | **Open Source Summit** | Paris | 05/12 - 06/12 | [CFP](http://cfp.opensourcesummit.paris/), [Website](http://www.opensourcesummit.paris/) | **31/08/2018**
 
 ### Belgium 🇧🇪


### PR DESCRIPTION
Le 15/09 est la date de délibération. Le CFP se termine le 31/08 (source : codeursenseine.cfp.io une fois connécté "Ouvert jusqu'au 31/08/2018 - Délibération le 15/09/2018")